### PR TITLE
Allow to show child components while image is loading

### DIFF
--- a/src/CacheManager.js
+++ b/src/CacheManager.js
@@ -25,7 +25,7 @@ const defaultOptions = {
  * it is considered cacheable if it is a url
  * @param {String} url
  */
-function isCacheable(url) {
+export function IsCacheable(url) {
     return (
         _.isString(url) &&
         (_.startsWith(url.toLowerCase(), "http://") ||
@@ -38,7 +38,7 @@ function isCacheable(url) {
  * @param {(path: String) => Promise<void>} getCachedFile
  */
 async function cacheUrl(url, options, getCachedFile) {
-    if (!isCacheable(url)) {
+    if (!IsCacheable(url)) {
         return Promise.reject(new Error("Url is not cacheable"));
     }
     const NewCache = async () => {
@@ -117,7 +117,7 @@ export class CacheManager {
      */
     async deleteUrl(url, options = {}) {
         try {
-            if (!isCacheable(url)) {
+            if (!IsCacheable(url)) {
                 throw new Error("Url is not cacheable");
             }
             const copy = { ...this.options, ...options };

--- a/src/CacheableImage.js
+++ b/src/CacheableImage.js
@@ -216,15 +216,22 @@ const CacheableImageComponent = (props, ref) => {
             ...imageProps,
             style: props.style,
             source,
-            children: LoadingIndicator ? (
-                <View style={[imageStyle, activityIndicatorStyle]}>
-                    <LoadingIndicator {...activityIndicatorProps} />
+            children: (
+                <View
+                    style={[
+                        imageStyle,
+                        LoadingIndicator && activityIndicatorStyle
+                    ]}>
+                    {LoadingIndicator ? (
+                        <LoadingIndicator {...activityIndicatorProps} />
+                    ) : (
+                        <ActivityIndicator
+                            {...activityIndicatorProps}
+                            style={activityIndicatorStyle}
+                        />
+                    )}
+                    {props.children}
                 </View>
-            ) : (
-                <ActivityIndicator
-                    {...activityIndicatorProps}
-                    style={activityIndicatorStyle}
-                />
             )
         });
     };

--- a/src/CacheableImage.js
+++ b/src/CacheableImage.js
@@ -160,7 +160,7 @@ const CacheableImageComponent = (props, ref) => {
         return <ImageBackground imageStyle={args.style} ref={ref} {...args} />;
     };
     const renderLoader = () => {
-        const imageStyle = [props.style, defaultStyles.loaderPlaceholder];
+        const imageStyle = [defaultStyles.loaderPlaceholder, props.style];
         const flattenStyle = StyleSheet.flatten(imageStyle);
         const activityIndicatorProps = _.omit(
             props.activityIndicatorProps ?? {

--- a/src/CacheableImage.js
+++ b/src/CacheableImage.js
@@ -64,7 +64,7 @@ const getCacheManagerOptions = props => {
 const getLoaderSize = (width = 16, height = 16) => {
     if (!_.isNumber(width)) width = 16;
     if (!_.isNumber(height)) height = 16;
-    const maxSize = 72;
+    const maxSize = 80;
     const min = Math.min(width, height);
     return min > maxSize + 5 ? maxSize : min - 5;
 };
@@ -151,7 +151,7 @@ const CacheableImageComponent = (props, ref) => {
         if (_.isFunction(props.renderImage)) {
             props.renderImage(args);
         }
-        return <ImageBackground imageStyle={args.style} ref={ref} {...args} />;
+        return <ImageBackground style={args.style} ref={ref} {...args} />;
     };
     const renderLoader = () => {
         const imageStyle = [props.style, defaultStyles.loaderPlaceholder];

--- a/src/CacheableImage.js
+++ b/src/CacheableImage.js
@@ -151,7 +151,7 @@ const CacheableImageComponent = (props, ref) => {
         if (_.isFunction(props.renderImage)) {
             props.renderImage(args);
         }
-        return <ImageBackground style={args.style} ref={ref} {...args} />;
+        return <ImageBackground imageStyle={args.style} ref={ref} {...args} />;
     };
     const renderLoader = () => {
         const imageStyle = [props.style, defaultStyles.loaderPlaceholder];

--- a/src/CacheableImage.js
+++ b/src/CacheableImage.js
@@ -193,18 +193,22 @@ const CacheableImageComponent = (props, ref) => {
             !source ||
             (Platform.OS === "android" && flattenStyle.borderRadius)
         ) {
-            if (LoadingIndicator) {
-                return (
-                    <View style={[imageStyle, activityIndicatorStyle]}>
-                        <LoadingIndicator {...activityIndicatorProps} />
-                    </View>
-                );
-            }
             return (
-                <ActivityIndicator
-                    {...activityIndicatorProps}
-                    style={[imageStyle, activityIndicatorStyle]}
-                />
+                <View
+                    style={[
+                        imageStyle,
+                        LoadingIndicator && activityIndicatorStyle
+                    ]}>
+                    {LoadingIndicator ? (
+                        <LoadingIndicator {...activityIndicatorProps} />
+                    ) : (
+                        <ActivityIndicator
+                            {...activityIndicatorProps}
+                            style={activityIndicatorStyle}
+                        />
+                    )}
+                    {props.children}
+                </View>
             );
         }
         // otherwise render an image with the defaultSource with the ActivityIndicator on top of it


### PR DESCRIPTION
Now the child components do not disappear while the image is loading, in addition, the alert "url argument must be string" is being avoided